### PR TITLE
feat(docker): add Xvfb for optional headed Chrome in scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ TELEGRAM_CHAT_ID=your_chat_id_here
 # Scheduler (optional - cron expression, Israel timezone)
 # Default: 0,30 8-23 * * * (every 30 min from 8:00 to 23:30 Tel-Aviv)
 # SCRAPE_CRON=0,30 8-23 * * *
+
+# Scraping in Docker: use a residential proxy to avoid ShieldSquare/CAPTCHA blocks
+# PROXY_URL=http://user:pass@proxy.example:8080
+
+# Optional: run Chrome in headed mode in Docker (the scheduler already runs
+# under xvfb-run, so just uncomment this to switch from headless to headed)
+# PUPPETEER_HEADLESS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM node:20-bookworm
 
 WORKDIR /app
 
-# Install dependencies for Puppeteer
+# Install dependencies for Puppeteer + Xvfb (virtual display for headed mode)
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg \
     ca-certificates \
     procps \
+    xvfb \
     libxss1 \
     libgconf-2-4 \
     libxtst6 \

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This project includes a comprehensive web scraping service for [Yad2](https://ww
 
 ### Running in Docker (scheduler / API)
 
-When you see logs like **"Bot protection detected"**, **"Captcha detected, retrying in 30s"**, or **"Waiting for challenge to auto-resolve"**, the site is blocking the scraper. In Docker this is common because:
+When you see logs like **"Bot protection detected"**, **"Captcha detected, retrying in 45s"**, or **"Waiting for challenge to auto-resolve"**, the site is blocking the scraper. In Docker this is common because:
 
 - Chrome runs in **headless** mode by default (easier for ShieldSquare to detect).
 - The container uses a **datacenter IP**, which is often flagged.
@@ -109,12 +109,7 @@ When you see logs like **"Bot protection detected"**, **"Captcha detected, retry
    Set `PROXY_URL` in your `.env` (e.g. `http://user:pass@residential-proxy.example:8080`). Use a **residential** proxy provider (e.g. Bright Data, Oxylabs, Smartproxy); datacenter proxies are often blocked too.
 
 2. **Pass the proxy into Docker**  
-   In `docker-compose.yml`, add to the scheduler (and api) service:
-   ```yaml
-   environment:
-     - PROXY_URL=${PROXY_URL}
-   ```
-   Then set `PROXY_URL` in your `.env`.
+   Set `PROXY_URL` in your `.env` — it is already wired into both the api and scheduler services.
 
 3. **Headed Chrome in Docker (already set up for the scheduler)**  
    The Docker image includes **Xvfb** (X Virtual Frame Buffer) and the scheduler runs under `xvfb-run`, so Chrome has a virtual display to attach to. To enable headed mode, set `PUPPETEER_HEADLESS=false` in your `.env` -- no extra container setup needed. Headed Chrome behaves more like a real browser and can help bypass bot detection.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ This project includes a comprehensive web scraping service for [Yad2](https://ww
 4. **Use residential proxies**: More likely to bypass detection
 5. **Consider headless browser detection**: Some sites detect headless browsers
 
+### Running in Docker (scheduler / API)
+
+When you see logs like **"Bot protection detected"**, **"Captcha detected, retrying in 30s"**, or **"Waiting for challenge to auto-resolve"**, the site is blocking the scraper. In Docker this is common because:
+
+- Chrome runs in **headless** mode by default (easier for ShieldSquare to detect).
+- The container uses a **datacenter IP**, which is often flagged.
+
+**What you can do:**
+
+1. **Use a residential proxy (recommended)**  
+   Set `PROXY_URL` in your `.env` (e.g. `http://user:pass@residential-proxy.example:8080`). Use a **residential** proxy provider (e.g. Bright Data, Oxylabs, Smartproxy); datacenter proxies are often blocked too.
+
+2. **Pass the proxy into Docker**  
+   In `docker-compose.yml`, add to the scheduler (and api) service:
+   ```yaml
+   environment:
+     - PROXY_URL=${PROXY_URL}
+   ```
+   Then set `PROXY_URL` in your `.env`.
+
+3. **Headed Chrome in Docker (already set up for the scheduler)**  
+   The Docker image includes **Xvfb** (X Virtual Frame Buffer) and the scheduler runs under `xvfb-run`, so Chrome has a virtual display to attach to. To enable headed mode, set `PUPPETEER_HEADLESS=false` in your `.env` -- no extra container setup needed. Headed Chrome behaves more like a real browser and can help bypass bot detection.
+
 ### Usage Examples
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -106,13 +106,10 @@ When you see logs like **"Bot protection detected"**, **"Captcha detected, retry
 **What you can do:**
 
 1. **Use a residential proxy (recommended)**  
-   Set `PROXY_URL` in your `.env` (e.g. `http://user:pass@residential-proxy.example:8080`). Use a **residential** proxy provider (e.g. Bright Data, Oxylabs, Smartproxy); datacenter proxies are often blocked too.
+   Set `PROXY_URL` in your `.env` (e.g. `http://user:pass@residential-proxy.example:8080`). Use a **residential** proxy provider (e.g. Bright Data, Oxylabs, Smartproxy); datacenter proxies are often blocked too. When running in Docker, this variable is already wired into both the **api** and **scheduler** services.
 
-2. **Pass the proxy into Docker**  
-   Set `PROXY_URL` in your `.env` — it is already wired into both the api and scheduler services.
-
-3. **Headed Chrome in Docker (already set up for the scheduler)**  
-   The Docker image includes **Xvfb** (X Virtual Frame Buffer) and the scheduler runs under `xvfb-run`, so Chrome has a virtual display to attach to. To enable headed mode, set `PUPPETEER_HEADLESS=false` in your `.env` -- no extra container setup needed. Headed Chrome behaves more like a real browser and can help bypass bot detection.
+2. **Headed Chrome in Docker (scheduler only)**  
+   The Docker image includes **Xvfb** (X Virtual Frame Buffer) and the **scheduler** runs under `xvfb-run`, so Chrome has a virtual display. To enable headed mode for the scheduler, set `PUPPETEER_HEADLESS=false` in your `.env`. The **api** service always runs headless (no virtual display) and does not support headed mode. Headed Chrome can help bypass bot detection.
 
 ### Usage Examples
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - DB_NAME=${DB_NAME:-homie_db}
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
+      - PROXY_URL=${PROXY_URL:-}
     ports:
       - "3001:8080"
     depends_on:
@@ -58,6 +59,8 @@ services:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
       - SCRAPE_CRON=${SCRAPE_CRON:-0,30 8-23 * * *}
+      - PROXY_URL=${PROXY_URL:-}
+      - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
     depends_on:
       mysql:
         condition: service_healthy
@@ -65,7 +68,7 @@ services:
       - homie_network
     volumes:
       - ./exports:/app/exports
-    command: npm run scheduler:start
+    command: xvfb-run -a npm run scheduler:start
     profiles:
       - scheduler
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
       - PROXY_URL=${PROXY_URL:-}
+      - PUPPETEER_HEADLESS=true
     ports:
       - "3001:8080"
     depends_on:
@@ -68,7 +69,7 @@ services:
       - homie_network
     volumes:
       - ./exports:/app/exports
-    command: xvfb-run -a npm run scheduler:start
+    command: ["/bin/sh", "-c", "/usr/bin/xvfb-run -a npm run scheduler:start"]
     profiles:
       - scheduler
 

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -383,14 +383,16 @@ app.post('/notifications/send', async (req, res) => {
       });
     }
 
-    await telegramService.sendBatch(unnotified);
-    await dbService.markAsNotified(unnotified.map((p) => p.id));
+    const sentIds = await telegramService.sendBatch(unnotified);
+    if (sentIds.length > 0) {
+      await dbService.markAsNotified(sentIds);
+    }
     await dbService.disconnect();
 
     return res.json({
       success: true,
-      message: `Sent Telegram notifications for ${unnotified.length} properties`,
-      sentCount: unnotified.length,
+      message: `Sent Telegram notifications for ${sentIds.length} of ${unnotified.length} properties`,
+      sentCount: sentIds.length,
       timestamp: new Date().toISOString()
     });
   } catch (error) {

--- a/src/services/enhanced-puppeteer-scraper.service.ts
+++ b/src/services/enhanced-puppeteer-scraper.service.ts
@@ -43,12 +43,27 @@ export class EnhancedPuppeteerScraperService {
       console.log(`🌐 Using proxy: ${cleaned.replace(/:[^:@]+@/, ':***@')}`);
     }
 
+    const headlessSource =
+      headlessEnv === 'false'
+        ? 'PUPPETEER_HEADLESS=false'
+        : headlessEnv === 'true'
+          ? 'PUPPETEER_HEADLESS=true'
+          : isDocker
+            ? 'default (Docker → headless)'
+            : 'default (local → headed)';
+
     this.browser = await puppeteer.launch({
       headless,
       ...(isDocker && { executablePath: '/usr/bin/google-chrome-stable' }),
       userDataDir: profileDir,
       args,
     });
+
+    console.log(
+      headless
+        ? `🌑 Chrome running in headless mode (${headlessSource})`
+        : `🖥️ Chrome running in headed mode (${headlessSource})`,
+    );
   }
 
   async closeBrowser(): Promise<void> {

--- a/src/services/enhanced-puppeteer-scraper.service.ts
+++ b/src/services/enhanced-puppeteer-scraper.service.ts
@@ -14,7 +14,7 @@ const USER_AGENTS = [
 ];
 
 const MAX_RETRIES = 3;
-const RETRY_DELAYS_MS = [30_000, 60_000, 120_000];
+const RETRY_DELAYS_MS = [45_000, 90_000, 180_000];
 
 export class EnhancedPuppeteerScraperService {
   private browser: Browser | null = null;
@@ -25,6 +25,8 @@ export class EnhancedPuppeteerScraperService {
     if (this.browser) return;
 
     const isDocker = process.env.DOCKER_ENV === 'true' || process.env.NODE_ENV === 'production';
+    const headlessEnv = process.env.PUPPETEER_HEADLESS;
+    const headless = headlessEnv === 'false' ? false : headlessEnv === 'true' ? true : isDocker;
     const profileDir = path.resolve(process.cwd(), 'browser-profile');
 
     const args = [
@@ -42,7 +44,7 @@ export class EnhancedPuppeteerScraperService {
     }
 
     this.browser = await puppeteer.launch({
-      headless: isDocker,
+      headless,
       ...(isDocker && { executablePath: '/usr/bin/google-chrome-stable' }),
       userDataDir: profileDir,
       args,

--- a/src/services/scraper-db.service.ts
+++ b/src/services/scraper-db.service.ts
@@ -63,8 +63,10 @@ export class ScraperDatabaseService {
         const unnotified = await this.database.getUnnotifiedProperties();
         if (unnotified.length > 0) {
           console.log(`📱 Sending Telegram notifications for ${unnotified.length} new properties...`);
-          await this.telegramService.sendBatch(unnotified);
-          await this.database.markAsNotified(unnotified.map((p) => p.id));
+          const sentIds = await this.telegramService.sendBatch(unnotified);
+          if (sentIds.length > 0) {
+            await this.database.markAsNotified(sentIds);
+          }
         }
       }
 

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -1,5 +1,8 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { PropertyItem } from '../interfaces/property.interface';
+
+/** Delay between messages (ms). Telegram allows ~20 msg/min to same private chat; 3.5s keeps us under that. */
+const DELAY_BETWEEN_MESSAGES_MS = 3500;
 
 export class TelegramService {
   private readonly token = process.env.TELEGRAM_BOT_TOKEN;
@@ -36,18 +39,51 @@ export class TelegramService {
     ].join('\n');
   }
 
-  async sendBatch(properties: PropertyItem[]): Promise<void> {
+  /**
+   * Sends Telegram alerts for each property, respecting rate limits (~20 msg/min to same chat).
+   * On 429 (Too Many Requests), waits for Retry-After and retries.
+   * @returns IDs of properties that were successfully sent (only these should be marked as notified).
+   */
+  async sendBatch(properties: PropertyItem[]): Promise<string[]> {
+    const sentIds: string[] = [];
     if (!this.isConfigured()) {
       console.warn('⚠️ Telegram not configured; skipping notifications');
-      return;
+      return sentIds;
     }
+
     for (const property of properties) {
-      try {
-        await this.sendPropertyAlert(property);
-        await new Promise((r) => setTimeout(r, 500));
-      } catch (error) {
-        console.error(`❌ Failed to send Telegram alert for property ${property.id}:`, error);
+      const ok = await this.sendOneWithRetry(property);
+      if (ok) sentIds.push(property.id);
+      await new Promise((r) => setTimeout(r, DELAY_BETWEEN_MESSAGES_MS));
+    }
+
+    if (properties.length > 0) {
+      console.log(`📱 Telegram: ${sentIds.length}/${properties.length} notifications sent`);
+      if (sentIds.length < properties.length) {
+        console.warn(`⚠️ ${properties.length - sentIds.length} failed; they will be retried on next run`);
       }
+    }
+    return sentIds;
+  }
+
+  private async sendOneWithRetry(property: PropertyItem, isRetry = false): Promise<boolean> {
+    try {
+      await this.sendPropertyAlert(property);
+      return true;
+    } catch (error) {
+      const axiosError = error as AxiosError<{ description?: string }>;
+      const status = axiosError.response?.status;
+      const retryAfter = axiosError.response?.headers?.['retry-after'];
+      const waitSec = typeof retryAfter === 'string' ? parseInt(retryAfter, 10) : NaN;
+
+      if (status === 429 && !isRetry && !Number.isNaN(waitSec) && waitSec > 0) {
+        console.warn(`⏳ Telegram rate limited; waiting ${waitSec}s before retry...`);
+        await new Promise((r) => setTimeout(r, waitSec * 1000));
+        return this.sendOneWithRetry(property, true);
+      }
+
+      console.error(`❌ Failed to send Telegram alert for property ${property.id}:`, axiosError.message);
+      return false;
     }
   }
 }

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -51,10 +51,13 @@ export class TelegramService {
       return sentIds;
     }
 
-    for (const property of properties) {
+    for (let i = 0; i < properties.length; i++) {
+      const property = properties[i];
       const ok = await this.sendOneWithRetry(property);
       if (ok) sentIds.push(property.id);
-      await new Promise((r) => setTimeout(r, DELAY_BETWEEN_MESSAGES_MS));
+      if (i < properties.length - 1) {
+        await new Promise((r) => setTimeout(r, DELAY_BETWEEN_MESSAGES_MS));
+      }
     }
 
     if (properties.length > 0) {
@@ -74,7 +77,12 @@ export class TelegramService {
       const axiosError = error as AxiosError<{ description?: string }>;
       const status = axiosError.response?.status;
       const retryAfter = axiosError.response?.headers?.['retry-after'];
-      const waitSec = typeof retryAfter === 'string' ? parseInt(retryAfter, 10) : NaN;
+      let waitSec = typeof retryAfter === 'string' ? parseInt(retryAfter, 10) : NaN;
+      const MAX_RETRY_AFTER_SEC = 120;
+      if (!Number.isNaN(waitSec) && waitSec > MAX_RETRY_AFTER_SEC) {
+        console.warn(`⏳ Telegram Retry-After ${waitSec}s capped to ${MAX_RETRY_AFTER_SEC}s`);
+        waitSec = MAX_RETRY_AFTER_SEC;
+      }
 
       if (status === 429 && !isRetry && !Number.isNaN(waitSec) && waitSec > 0) {
         console.warn(`⏳ Telegram rate limited; waiting ${waitSec}s before retry...`);

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -74,10 +74,14 @@ export class TelegramService {
       await this.sendPropertyAlert(property);
       return true;
     } catch (error) {
-      const axiosError = error as AxiosError<{ description?: string }>;
+      const axiosError = error as AxiosError<{ description?: string; parameters?: { retry_after?: number } }>;
       const status = axiosError.response?.status;
-      const retryAfter = axiosError.response?.headers?.['retry-after'];
-      let waitSec = typeof retryAfter === 'string' ? parseInt(retryAfter, 10) : NaN;
+      const retryAfterHeader = axiosError.response?.headers?.['retry-after'];
+      const retryAfterBody = axiosError.response?.data?.parameters?.retry_after;
+      let waitSec = typeof retryAfterHeader === 'string' ? parseInt(retryAfterHeader, 10) : NaN;
+      if (Number.isNaN(waitSec) && typeof retryAfterBody === 'number' && retryAfterBody > 0) {
+        waitSec = retryAfterBody;
+      }
       const MAX_RETRY_AFTER_SEC = 120;
       if (!Number.isNaN(waitSec) && waitSec > MAX_RETRY_AFTER_SEC) {
         console.warn(`⏳ Telegram Retry-After ${waitSec}s capped to ${MAX_RETRY_AFTER_SEC}s`);


### PR DESCRIPTION
- Install xvfb in Dockerfile for virtual display
- Run scheduler with xvfb-run -a so Chrome can use headed mode
- Add PUPPETEER_HEADLESS env (default true) for optional headed mode
- Update .env.example and README with headed Chrome instructions

Made-with: Cursor