### PR TITLE
fix: harden Docker scraper against bot protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ logs
 # Puppeteer persistent browser profile (cookies, cache – recreated at runtime)
 browser-profile/
 browser-profile-docker/
+browser-profile-docker-api/
+browser-profile-docker-scheduler/
 browser-profile-docker-test/
 
 exports/

--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,7 @@ logs
 
 # Puppeteer persistent browser profile (cookies, cache – recreated at runtime)
 browser-profile/
+browser-profile-docker/
+browser-profile-docker-test/
 
 exports/

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
     && chown -R pptruser:pptruser /home/pptruser \
     && chown -R pptruser:pptruser /app
 
+# So Xvfb can create display socket when running as pptruser (for docker:scrape / scheduler)
+RUN mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+
 # Switch to non-root user
 USER pptruser
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ When you see logs like **"Bot protection detected"**, **"Captcha detected, retry
    Set `PROXY_URL` in your `.env` (e.g. `http://user:pass@residential-proxy.example:8080`). Use a **residential** proxy provider (e.g. Bright Data, Oxylabs, Smartproxy); datacenter proxies are often blocked too. When running in Docker, this variable is already wired into both the **api** and **scheduler** services.
 
 2. **Headed Chrome in Docker (scheduler only)**  
-   The Docker image includes **Xvfb** (X Virtual Frame Buffer) and the **scheduler** runs under `xvfb-run`, so Chrome has a virtual display. To enable headed mode for the scheduler, set `PUPPETEER_HEADLESS=false` in your `.env`. The **api** service always runs headless (no virtual display) and does not support headed mode. Headed Chrome can help bypass bot detection.
+   The Docker image includes **Xvfb** and the **scheduler** runs under `xvfb-run`, so Chrome has a virtual display. The scheduler **defaults to headed mode** in Docker (same as running locally) to avoid bot detection. To force headless in the scheduler, set `PUPPETEER_HEADLESS=true` in your `.env`. The **api** service always runs headless and does not support headed mode.
+
+3. **Persistent Docker browser profile**  
+   The scheduler (and `npm run docker:scrape`) mount `./browser-profile-docker` into the container so Docker runs can keep their own cookies and challenge state across runs without sharing a macOS Chrome profile. If the container cannot write to `browser-profile-docker`, run `chmod -R 777 browser-profile-docker` once.
 
 ### Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,28 @@ When you see logs like **"Bot protection detected"**, **"Captcha detected, retry
    The Docker image includes **Xvfb** and the **scheduler** runs under `xvfb-run`, so Chrome has a virtual display. The scheduler **defaults to headed mode** in Docker (same as running locally) to avoid bot detection. To force headless in the scheduler, set `PUPPETEER_HEADLESS=true` in your `.env`. The **api** service always runs headless and does not support headed mode.
 
 3. **Persistent Docker browser profile**  
-   The scheduler (and `npm run docker:scrape`) mount `./browser-profile-docker` into the container so Docker runs can keep their own cookies and challenge state across runs without sharing a macOS Chrome profile. If the container cannot write to `browser-profile-docker`, run `chmod -R 777 browser-profile-docker` once.
+   The **api** and **scheduler** services each use a separate profile directory (`./browser-profile-docker-api` and `./browser-profile-docker-scheduler`) so they do not contend for Chrome’s profile lock. The scheduler (and `npm run docker:scrape`) use the scheduler profile so Docker runs can keep cookies and challenge state across runs. If the container cannot write to a profile directory, ensure it is owned by your user and only accessible to you, for example:
+   ```bash
+   chown -R "$(id -u):$(id -g)" browser-profile-docker-api browser-profile-docker-scheduler
+   chmod -R 700 browser-profile-docker-api browser-profile-docker-scheduler
+   ```
+
+**Verify Docker setup (optional)**  
+Before first run, create the profile directories so bind mounts work and optionally validate the stack:
+
+```bash
+npm run docker:verify
+```
+
+Then bring up the stack and run a one-off scrape to confirm everything works:
+
+```bash
+docker-compose --profile scheduler up -d
+docker-compose --profile scheduler logs -f api scheduler   # Ctrl+C to stop following
+
+# Or run a one-off scrape (uses scheduler profile)
+npm run docker:scrape
+```
 
 ### Usage Examples
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - homie_network
     volumes:
       - ./exports:/app/exports
+      - ./browser-profile-docker:/app/browser-profile-docker
 
   scheduler:
     build: .
@@ -61,7 +62,7 @@ services:
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
       - SCRAPE_CRON=${SCRAPE_CRON:-0,30 8-23 * * *}
       - PROXY_URL=${PROXY_URL:-}
-      - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-true}
+      - PUPPETEER_HEADLESS=${PUPPETEER_HEADLESS:-false}
     depends_on:
       mysql:
         condition: service_healthy
@@ -69,6 +70,7 @@ services:
       - homie_network
     volumes:
       - ./exports:/app/exports
+      - ./browser-profile-docker:/app/browser-profile-docker
     command: ["/bin/sh", "-c", "/usr/bin/xvfb-run -a npm run scheduler:start"]
     profiles:
       - scheduler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - homie_network
     volumes:
       - ./exports:/app/exports
-      - ./browser-profile-docker:/app/browser-profile-docker
+      - ./browser-profile-docker-api:/app/browser-profile-docker
 
   scheduler:
     build: .
@@ -70,7 +70,7 @@ services:
       - homie_network
     volumes:
       - ./exports:/app/exports
-      - ./browser-profile-docker:/app/browser-profile-docker
+      - ./browser-profile-docker-scheduler:/app/browser-profile-docker
     command: ["/bin/sh", "-c", "/usr/bin/xvfb-run -a npm run scheduler:start"]
     profiles:
       - scheduler

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "docker:down": "docker-compose down",
     "docker:logs": "docker-compose logs -f",
     "docker:logs:api": "docker-compose logs -f api",
-    "docker:logs:mysql": "docker-compose logs -f mysql"
+    "docker:logs:mysql": "docker-compose logs -f mysql",
+    "docker:scrape": "docker-compose run --rm scheduler /bin/sh -c \"/usr/bin/Xvfb :99 -screen 0 1920x1080x24 & sleep 2 && export DISPLAY=:99 && node dist/index.js --enhanced --db\""
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "docker:logs": "docker-compose logs -f",
     "docker:logs:api": "docker-compose logs -f api",
     "docker:logs:mysql": "docker-compose logs -f mysql",
-    "docker:scrape": "docker-compose run --rm scheduler /bin/sh -c \"/usr/bin/Xvfb :99 -screen 0 1920x1080x24 & sleep 2 && export DISPLAY=:99 && node dist/index.js --enhanced --db\""
+    "docker:scrape": "docker-compose run --rm scheduler /bin/sh -c \"/usr/bin/Xvfb :99 -screen 0 1920x1080x24 & sleep 2 && export DISPLAY=:99 && node dist/index.js --enhanced --db\"",
+    "docker:verify": "mkdir -p browser-profile-docker-api browser-profile-docker-scheduler && docker-compose --profile scheduler config > /dev/null && echo \"Profile dirs created; docker-compose config OK.\""
   },
   "keywords": [],
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,29 +181,14 @@ async function scrapeWithEnhancedPuppeteer(): Promise<void> {
       if (saveToDatabase) {
         try {
           console.log('📀 Saving to database...');
-          let totalInserted = 0;
-          let totalUpdated = 0;
-          let totalSkipped = 0;
-          
-          for (let i = 0; i < targetUrls.length; i++) {
-            const targetUrl = targetUrls[i];
-            console.log(`📀 [${i + 1}/${targetUrls.length}] Saving data from: ${targetUrl!.split('neighborhood=')[1] ? 'neighborhood ' + targetUrl!.split('neighborhood=')[1] : 'location ' + (i + 1)}...`);
-            
-            const dbResult = await scraperDatabaseService.scrapeAndSaveToDatabase(targetUrl!, {
-              exportCsv: false, // We already exported to CSV above
-              cleanOldData: i === 0, // Only clean on first URL
-              cleanOldDays: 30
-            });
-            
-            if (dbResult.success && dbResult.dbStats) {
-              totalInserted += dbResult.dbStats.inserted || 0;
-              totalUpdated += dbResult.dbStats.updated || 0;
-              totalSkipped += dbResult.dbStats.skipped || 0;
-            }
-          }
-          
+          const dbStats = await scraperDatabaseService.savePropertiesToDatabase(filteredProperties, {
+            exportCsv: false, // We already exported to CSV above
+            cleanOldData: true,
+            cleanOldDays: 30
+          });
+
           console.log('✅ Database save completed successfully!');
-          console.log(`📀 Combined Database Stats: ${totalInserted} new, ${totalUpdated} updated, ${totalSkipped} skipped`);
+          console.log(`📀 Combined Database Stats: ${dbStats.inserted} new, ${dbStats.updated} updated, ${dbStats.skipped} skipped`);
         } catch (error) {
           console.error('❌ Database operation failed:', error);
         }
@@ -270,21 +255,17 @@ async function scrapeWithDatabaseIntegration(): Promise<void> {
     console.log(`📊 Total properties scraped: ${totalItems}`);
     console.log(`📀 Combined Database Stats: ${totalInserted} new, ${totalUpdated} updated, ${totalSkipped} skipped`);
     
-    // Get final statistics from the last successful scrape
+    // Get final statistics without triggering another scrape
     if (totalSuccessful > 0) {
       try {
-        const finalResult = await scraperDatabaseService.scrapeAndSaveToDatabase(targetUrls[0]!, {
-          exportCsv: false,
-          cleanOldData: false,
-          cleanOldDays: 30
-        });
-        
-        if (finalResult.dbStats?.statistics) {
+        const finalStats = await scraperDatabaseService.getDatabaseStatistics();
+
+        if (finalStats) {
           console.log('\n📊 Final Database Statistics:');
-          console.log(`   Today's Properties: ${finalResult.dbStats.statistics.todayProperties}`);
-          console.log(`   Average Price: ₪${finalResult.dbStats.statistics.avgPrice}`);
+          console.log(`   Today's Properties: ${finalStats.todayProperties}`);
+          console.log(`   Average Price: ₪${finalStats.avgPrice}`);
           console.log(`   Top Locations:`);
-          finalResult.dbStats.statistics.locationCounts.slice(0, 5).forEach((loc: any, index: number) => {
+          finalStats.locationCounts.slice(0, 5).forEach((loc: any, index: number) => {
             console.log(`     ${index + 1}. ${loc.location}: ${loc.count} properties`);
           });
         }

--- a/src/services/enhanced-puppeteer-scraper.service.ts
+++ b/src/services/enhanced-puppeteer-scraper.service.ts
@@ -2,39 +2,58 @@ import puppeteer from 'puppeteer-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import { Browser, Page } from 'puppeteer';
 import { PropertyItem, ScrapingResult } from '../interfaces/property.interface';
+import fs from 'fs';
 import path from 'path';
+import os from 'os';
 
 puppeteer.use(StealthPlugin());
-
-const USER_AGENTS = [
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36',
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-];
 
 const MAX_RETRIES = 3;
 const RETRY_DELAYS_MS = [45_000, 90_000, 180_000];
 
 export class EnhancedPuppeteerScraperService {
   private browser: Browser | null = null;
-  private chosenUA = USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)]!;
+  private page: Page | null = null;
   private homepageWarmedUp = false;
+  private activeProfileDir: string | null = null;
+  private usingTempProfile = false;
+  private launchDiagnosticsLogged = false;
+  private resolvedUserAgent: string | null = null;
+  private readonly acceptLanguage = 'he-IL,he;q=0.9,en-US;q=0.8,en;q=0.7';
+  private readonly timezone = 'Asia/Jerusalem';
+  private readonly geolocation = { latitude: 32.0853, longitude: 34.7818, accuracy: 25 };
 
-  async initBrowser(): Promise<void> {
+  async initBrowser(useTempProfile = false): Promise<void> {
     if (this.browser) return;
 
     const isDocker = process.env.DOCKER_ENV === 'true' || process.env.NODE_ENV === 'production';
     const headlessEnv = process.env.PUPPETEER_HEADLESS;
     const headless = headlessEnv === 'false' ? false : headlessEnv === 'true' ? true : isDocker;
-    const profileDir = path.resolve(process.cwd(), 'browser-profile');
+    // Persistent profile: reuse cookies/session (fewer bot prompts). Temp profile: avoid "Chrome opens then closes" when the persistent profile is locked (e.g. another Chrome using it or leftover lock).
+    const persistentProfileDir = path.resolve(
+      process.cwd(),
+      isDocker ? 'browser-profile-docker' : 'browser-profile',
+    );
+    const profileDir = useTempProfile
+      ? path.join(os.tmpdir(), `puppeteer-profile-${process.pid}-${Date.now()}`)
+      : persistentProfileDir;
+    await this.cleanupStaleProfileLocks(profileDir);
 
     const args = [
       '--no-sandbox',
       '--disable-setuid-sandbox',
       '--disable-dev-shm-usage',
       '--disable-blink-features=AutomationControlled',
+      '--window-size=1920,1080',
+      '--lang=he-IL',
+      '--enable-webgl',
+      '--ignore-gpu-blocklist',
+      '--use-angle=swiftshader-webgl',
+      '--use-gl=angle',
     ];
+    if (headless) {
+      args.push('--headless=new');
+    }
 
     const proxyUrl = process.env.PROXY_URL;
     if (proxyUrl) {
@@ -52,25 +71,85 @@ export class EnhancedPuppeteerScraperService {
             ? 'default (Docker → headless)'
             : 'default (local → headed)';
 
-    this.browser = await puppeteer.launch({
+    if (isDocker && !headless) {
+      const display = process.env.DISPLAY || '';
+      if (!display) {
+        console.warn('⚠️ DISPLAY is not set — Chrome may fall back to headless. Ensure the process is run under xvfb-run (e.g. xvfb-run -a node ...).');
+      } else {
+        console.log(`🖥️ Virtual display: DISPLAY=${display}`);
+      }
+    }
+
+    const launchOptions: Parameters<typeof puppeteer.launch>[0] = {
       headless,
       ...(isDocker && { executablePath: '/usr/bin/google-chrome-stable' }),
       userDataDir: profileDir,
       args,
-    });
+    };
+    if (isDocker && !headless && process.env.DISPLAY) {
+      launchOptions.env = { ...process.env, DISPLAY: process.env.DISPLAY };
+    }
+
+    const isTargetClosedError = (e: unknown): boolean => {
+      const err = e as Error & { cause?: unknown };
+      const msg = err?.message ? err.message + (err.cause != null ? String(err.cause) : '') : String(e);
+      return /Target closed|Protocol error.*Target\.(setAutoAttach|setDiscoverTargets)/i.test(msg);
+    };
+
+    try {
+      this.browser = await puppeteer.launch(launchOptions);
+      await this.browser.defaultBrowserContext().overridePermissions('https://www.yad2.co.il', ['geolocation']);
+      // Verify the browser stays alive (Chrome can exit right after launch with a locked profile).
+      this.page = await this.browser.newPage();
+      await this.preparePage(this.page);
+      this.activeProfileDir = profileDir;
+      this.usingTempProfile = useTempProfile;
+      this.resolvedUserAgent = await this.browser.userAgent();
+    } catch (e) {
+      if (this.page) {
+        try {
+          await this.page.close();
+        } catch {
+          /* ignore */
+        }
+        this.page = null;
+      }
+      if (this.browser) {
+        try {
+          await this.browser.close();
+        } catch {
+          /* ignore */
+        }
+        this.browser = null;
+      }
+      if (!useTempProfile && isTargetClosedError(e)) {
+        console.warn('⚠️ Browser exited immediately (profile may be in use). Retrying with a temporary profile for this run.');
+        return this.initBrowser(true);
+      }
+      throw e;
+    }
 
     console.log(
       headless
         ? `🌑 Chrome running in headless mode (${headlessSource})`
         : `🖥️ Chrome running in headed mode (${headlessSource})`,
     );
+    console.log(
+      `📁 Browser profile: ${this.activeProfileDir}${this.usingTempProfile ? ' (temporary fallback)' : ''}`,
+    );
+    console.log(`🌐 Browser runtime: ${await this.browser.version()}`);
   }
 
   async closeBrowser(): Promise<void> {
     if (this.browser) {
       await this.browser.close();
       this.browser = null;
+      this.page = null;
       this.homepageWarmedUp = false;
+      this.launchDiagnosticsLogged = false;
+      this.activeProfileDir = null;
+      this.usingTempProfile = false;
+      this.resolvedUserAgent = null;
     }
   }
 
@@ -165,10 +244,7 @@ export class EnhancedPuppeteerScraperService {
 
     try {
       if (!this.browser) throw new Error('Browser not initialized');
-      page = await this.browser.newPage();
-
-      await this.applyStealthOverrides(page);
-      await this.setViewportAndHeaders(page);
+      page = await this.getOrCreatePage();
 
       if (!this.homepageWarmedUp) {
         await this.warmUpWithHomepage(page);
@@ -218,8 +294,6 @@ export class EnhancedPuppeteerScraperService {
         timestamp: new Date(),
         totalItems: 0,
       };
-    } finally {
-      if (page) await page.close();
     }
   }
 
@@ -252,6 +326,18 @@ export class EnhancedPuppeteerScraperService {
         get: () => ['he', 'he-IL', 'en-US', 'en'],
       });
 
+      Object.defineProperty(navigator, 'language', {
+        get: () => 'he-IL',
+      });
+
+      Object.defineProperty(navigator, 'hardwareConcurrency', {
+        get: () => 8,
+      });
+
+      Object.defineProperty(navigator, 'deviceMemory', {
+        get: () => 8,
+      });
+
       const originalQuery = window.navigator.permissions.query;
       window.navigator.permissions.query = (parameters: any) =>
         originalQuery.call(window.navigator.permissions, parameters);
@@ -282,11 +368,21 @@ export class EnhancedPuppeteerScraperService {
       isLandscape: true,
     });
 
-    await page.setUserAgent(this.chosenUA);
+    const chosenUA = process.env.PUPPETEER_USER_AGENT?.trim() || this.resolvedUserAgent || (await page.browser().userAgent());
+    await this.configureBrowserIdentity(page, chosenUA);
 
-    await page.setExtraHTTPHeaders({
-      'Accept-Language': 'he,he-IL;q=0.9,en-US;q=0.8,en;q=0.7',
-    });
+    if (!this.launchDiagnosticsLogged) {
+      const runtimeDetails = await page.evaluate(() => ({
+        userAgent: navigator.userAgent,
+        platform: navigator.platform,
+        language: navigator.language,
+        languages: navigator.languages,
+        webdriver: navigator.webdriver,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }));
+      console.log('🧭 Browser fingerprint:', runtimeDetails);
+      this.launchDiagnosticsLogged = true;
+    }
   }
 
   // ── Homepage warmup (referrer chain) ───────────────────────────
@@ -322,10 +418,12 @@ export class EnhancedPuppeteerScraperService {
 
     await page.mouse.click(centerX, centerY);
     await this.randomDelay(2000, 4000);
+    await this.waitForPotentialNavigation(page, 12_000);
 
     // Phase 2: wait patiently for auto-resolve (ShieldSquare JS challenge timeout)
     console.log('⏳ Waiting for challenge to auto-resolve...');
     await this.randomDelay(30_000, 45_000);
+    await this.waitForPotentialNavigation(page, 12_000);
 
     if (!(await this.isBotProtectionActive(page))) return true;
 
@@ -336,6 +434,7 @@ export class EnhancedPuppeteerScraperService {
     const clickY = viewport ? Math.random() * viewport.height * 0.5 + viewport.height * 0.25 : 300;
     await page.mouse.click(clickX, clickY);
     await this.randomDelay(20_000, 35_000);
+    await this.waitForPotentialNavigation(page, 12_000);
 
     return !(await this.isBotProtectionActive(page));
   }
@@ -574,5 +673,80 @@ export class EnhancedPuppeteerScraperService {
   private async randomDelay(min: number, max: number): Promise<void> {
     const delay = Math.floor(Math.random() * (max - min + 1)) + min;
     await new Promise(resolve => setTimeout(resolve, delay));
+  }
+
+  private async cleanupStaleProfileLocks(profileDir: string): Promise<void> {
+    const lockFiles = ['SingletonLock', 'SingletonSocket', 'SingletonCookie', 'DevToolsActivePort'];
+
+    for (const fileName of lockFiles) {
+      const filePath = path.join(profileDir, fileName);
+      try {
+        await fs.promises.rm(filePath, { force: true });
+      } catch {
+        // Ignore cleanup failures; Chrome may still be able to launch.
+      }
+    }
+  }
+
+  private async getOrCreatePage(): Promise<Page> {
+    if (this.page && !this.page.isClosed()) {
+      return this.page;
+    }
+
+    if (!this.browser) {
+      throw new Error('Browser not initialized');
+    }
+
+    this.page = await this.browser.newPage();
+    await this.preparePage(this.page);
+    return this.page;
+  }
+
+  private async preparePage(page: Page): Promise<void> {
+    await this.applyStealthOverrides(page);
+    await this.setViewportAndHeaders(page);
+    await page.setGeolocation(this.geolocation);
+  }
+
+  private async configureBrowserIdentity(page: Page, userAgent: string): Promise<void> {
+    const client = await page.createCDPSession();
+    const chromeVersion = /Chrome\/(\d+)/.exec(userAgent)?.[1] ?? '145';
+    const metadata = {
+      brands: [
+        { brand: 'Google Chrome', version: chromeVersion },
+        { brand: 'Chromium', version: chromeVersion },
+        { brand: 'Not.A/Brand', version: '24' },
+      ],
+      fullVersion: `${chromeVersion}.0.0.0`,
+      platform: 'Linux',
+      platformVersion: '6.1.0',
+      architecture: 'x86',
+      model: '',
+      mobile: false,
+      wow64: false,
+      bitness: '64',
+    };
+
+    await client.send('Network.enable');
+    await client.send('Network.setUserAgentOverride', {
+      userAgent,
+      acceptLanguage: this.acceptLanguage,
+      platform: 'Linux x86_64',
+      userAgentMetadata: metadata,
+    } as any);
+    await client.send('Emulation.setTimezoneOverride', { timezoneId: this.timezone });
+    await client.send('Emulation.setLocaleOverride', { locale: 'he-IL' } as any);
+
+    await page.setExtraHTTPHeaders({
+      'Accept-Language': this.acceptLanguage,
+    });
+  }
+
+  private async waitForPotentialNavigation(page: Page, timeout: number): Promise<void> {
+    try {
+      await page.waitForNavigation({ waitUntil: 'networkidle2', timeout });
+    } catch {
+      /* no navigation happened */
+    }
   }
 }

--- a/src/services/scraper-db.service.ts
+++ b/src/services/scraper-db.service.ts
@@ -2,7 +2,26 @@ import { EnhancedPuppeteerScraperService } from './enhanced-puppeteer-scraper.se
 import { DatabaseService } from './database.service';
 import { CsvExportService } from './csv-export.service';
 import { TelegramService } from './telegram.service';
-import { ScrapingResult } from '../interfaces/property.interface';
+import { PropertyItem, ScrapingResult } from '../interfaces/property.interface';
+
+type SaveOptions = {
+  exportCsv?: boolean;
+  cleanOldData?: boolean;
+  cleanOldDays?: number;
+};
+
+type SaveResult = {
+  inserted: number;
+  updated: number;
+  skipped: number;
+  totalInDb: number;
+  statistics: {
+    totalProperties: number;
+    todayProperties: number;
+    avgPrice: number;
+    locationCounts: Array<{ location: string; count: number }>;
+  };
+};
 
 export class ScraperDatabaseService {
   private scraper: EnhancedPuppeteerScraperService;
@@ -20,27 +39,8 @@ export class ScraperDatabaseService {
   /**
    * Scrape properties and save to database
    */
-  async scrapeAndSaveToDatabase(url: string, options: {
-    exportCsv?: boolean;
-    cleanOldData?: boolean;
-    cleanOldDays?: number;
-  } = {}): Promise<ScrapingResult & { dbStats?: any }> {
+  async scrapeAndSaveToDatabase(url: string, options: SaveOptions = {}): Promise<ScrapingResult & { dbStats?: SaveResult }> {
     try {
-      // Connect to database
-      await this.database.connect();
-      
-      // Ensure table exists
-      await this.database.createTable();
-
-      // Clean old data if requested
-      if (options.cleanOldData) {
-        await this.database.deleteOldProperties(options.cleanOldDays || 30);
-      }
-
-      // Get initial count
-      const initialCount = await this.database.getPropertiesCount();
-      console.log(`📊 Initial database count: ${initialCount} properties`);
-
       // Scrape properties
       console.log('🔍 Starting property scraping...');
       const scrapingResult = await this.scraper.scrapeProperties(url);
@@ -49,16 +49,43 @@ export class ScraperDatabaseService {
         return scrapingResult;
       }
 
-    // Filter properties for CSV export (same logic as before)
-    const filteredProperties = scrapingResult.data.filter(property => 
-        property.link && property.link.trim() !== '' && 
-        property.price !== 'Price not found'
-    );
+      const dbStats = await this.savePropertiesToDatabase(scrapingResult.data, options);
 
-      // Save to database (only properties with links)
+      return {
+        ...scrapingResult,
+        dbStats,
+      };
+
+    } catch (error) {
+      console.error('❌ Scraper database service failed:', error);
+      throw error;
+    } finally {
+      await this.scraper.closeBrowser();
+    }
+  }
+
+  /**
+   * Save already-scraped properties to the database without triggering another scrape.
+   */
+  async savePropertiesToDatabase(properties: PropertyItem[], options: SaveOptions = {}): Promise<SaveResult> {
+    try {
+      await this.database.connect();
+      await this.database.createTable();
+
+      if (options.cleanOldData) {
+        await this.database.deleteOldProperties(options.cleanOldDays || 30);
+      }
+
+      const initialCount = await this.database.getPropertiesCount();
+      console.log(`📊 Initial database count: ${initialCount} properties`);
+
+      const filteredProperties = properties.filter(property =>
+        property.link && property.link.trim() !== '' &&
+        property.price !== 'Price not found',
+      );
+
       const { inserted, updated, skipped } = await this.database.upsertProperties(filteredProperties);
 
-      // Send Telegram notifications for unnotified properties
       if (this.telegramService.isConfigured()) {
         const unnotified = await this.database.getUnnotifiedProperties();
         if (unnotified.length > 0) {
@@ -70,14 +97,12 @@ export class ScraperDatabaseService {
         }
       }
 
-      // Export to CSV if requested
       if (options.exportCsv) {
         await this.csvExport.exportToCSVEnhanced(filteredProperties);
       }
 
-      // Get final statistics
       const finalStats = await this.database.getStatistics();
-      
+
       console.log('📊 Final Database Statistics:');
       console.log(`   Total Properties: ${finalStats.totalProperties}`);
       console.log(`   Today's Properties: ${finalStats.todayProperties}`);
@@ -88,23 +113,17 @@ export class ScraperDatabaseService {
       });
 
       return {
-        ...scrapingResult,
-        dbStats: {
-          inserted,
-          updated,
-          skipped,
-          totalInDb: finalStats.totalProperties,
-          statistics: finalStats
-        }
+        inserted,
+        updated,
+        skipped,
+        totalInDb: finalStats.totalProperties,
+        statistics: finalStats,
       };
-
     } catch (error) {
-      console.error('❌ Scraper database service failed:', error);
+      console.error('❌ Failed to save already-scraped properties to database:', error);
       throw error;
     } finally {
-      // Always disconnect
       await this.database.disconnect();
-      await this.scraper.closeBrowser();
     }
   }
 

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -53,6 +53,7 @@ export class TelegramService {
 
     for (let i = 0; i < properties.length; i++) {
       const property = properties[i];
+      if (!property) continue;
       const ok = await this.sendOneWithRetry(property);
       if (ok) sentIds.push(property.id);
       if (i < properties.length - 1) {


### PR DESCRIPTION
## Summary
- align the Docker Puppeteer runtime with a persistent Docker-only browser profile, locale/timezone settings, and a single-page session so ShieldSquare stops forcing repeated retries
- save already-scraped results directly to the database so `docker:scrape` does not re-scrape the same URLs before persisting
- update Docker scheduler/docs to use the latest headed scraping flow and ignore generated browser-profile artifacts

## Test plan
- [x] `npm run build`
- [x] `docker compose build scheduler`
- [x] `npm run docker:scrape`
- [x] Verified Docker scrape completed both neighborhoods without captcha retry loops during the initial scrape pass
- [x] `docker compose --profile scheduler up -d --build --force-recreate scheduler`

Made with [Cursor](https://cursor.com)